### PR TITLE
Remove object files duplicated in $^ make variable, links now (on my machine)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,6 @@ all: luksunlock
 
 luksunlock: $(OBJECTS)
 	$(CC) $(ALL_LDFLAGS) $(LDFLAGS) -o luksunlock $^ \
-		luksunlock.o minui/events.o minui/graphics.o minui/resources.o \
 		$(LOCAL)/lib/libpng.a -lz -llog -lpixelflinger
 
 


### PR DESCRIPTION
I made this change to build/link successfully, on my Nexus One.

I do get the following warnings, but the built executable will run at init time or from my booted phone.

> ld: warning: libcutils.so, needed by external/data/local/lib/libpixelflinger.so, not found (try using -rpath or -rpath-link)
> ld: warning: libhardware_legacy.so, needed by external/data/local/lib/libpixelflinger.so, not found (try using -rpath or -rpath-link)
